### PR TITLE
Add Stripe Refund Support

### DIFF
--- a/src/Payum/Core/Action/RefundPaymentAction.php
+++ b/src/Payum/Core/Action/RefundPaymentAction.php
@@ -1,0 +1,52 @@
+<?php
+namespace Payum\Core\Action;
+
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Model\RefundInterface;
+use Payum\Core\Request\Refund;
+use Payum\Core\Request\Convert;
+use Payum\Core\Request\GetHumanStatus;
+
+class RefundPaymentAction extends GatewayAwareAction
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param Capture $request
+     */
+    public function execute($request)
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        /** @var $refund RefundInterface */
+        $refund = $request->getModel();
+
+        $this->gateway->execute($status = new GetHumanStatus($refund));
+        if ($status->isNew()) {
+            $this->gateway->execute($convert = new Convert($refund, 'array', $request->getToken()));
+
+            $refund->setDetails($convert->getResult());
+        }
+
+        $details = ArrayObject::ensureArrayObject($refund->getDetails());
+
+        $request->setModel($details);
+        try {
+            $this->gateway->execute($request);
+        } finally {
+            $refund->setDetails($details);
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Refund &&
+            $request->getModel() instanceof RefundInterface
+        ;
+    }
+}

--- a/src/Payum/Core/CoreGatewayFactory.php
+++ b/src/Payum/Core/CoreGatewayFactory.php
@@ -15,6 +15,7 @@ use Http\Message\StreamFactory\DiactorosStreamFactory;
 use Http\Message\StreamFactory\GuzzleStreamFactory;
 use Payum\Core\Action\AuthorizePaymentAction;
 use Payum\Core\Action\CapturePaymentAction;
+use Payum\Core\Action\RefundPaymentAction;
 use Payum\Core\Action\ExecuteSameRequestWithModelDetailsAction;
 use Payum\Core\Action\GetCurrencyAction;
 use Payum\Core\Action\GetTokenAction;
@@ -150,6 +151,7 @@ class CoreGatewayFactory implements GatewayFactoryInterface
             },
             'payum.action.get_http_request' => new GetHttpRequestAction(),
             'payum.action.capture_payment' => new CapturePaymentAction(),
+            'payum.action.refund_payment' => new RefundPaymentAction(),
             'payum.action.authorize_payment' => new AuthorizePaymentAction(),
             'payum.action.payout_payout' => new PayoutPayoutAction(),
             'payum.action.execute_same_request_with_model_details' => new ExecuteSameRequestWithModelDetailsAction(),

--- a/src/Payum/Core/Model/Refund.php
+++ b/src/Payum/Core/Model/Refund.php
@@ -1,0 +1,79 @@
+<?php
+namespace Payum\Core\Model;
+
+class Refund implements RefundInterface
+{
+    /**
+     * @var string
+     */
+    protected $originalTransactionId;
+
+    /**
+     * @var int
+     */
+    protected $amount;
+
+    /**
+     * @var array
+     */
+    protected $details;
+
+    public function __construct()
+    {
+        $this->details = [];
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getOriginalTransactionId()
+    {
+        return $this->originalTransactionId;
+    }
+
+    /**
+     * @param string $transactionId
+     */
+    public function setOriginalTransactionId($transactionId)
+    {
+        $this->originalTransactionId = $transactionId;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getAmount()
+    {
+        return $this->amount;
+    }
+
+    /**
+     * @param int $amount
+     */
+    public function setAmount($amount)
+    {
+        $this->amount = $amount;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function getDetails()
+    {
+        return $this->details;
+    }
+
+    /**
+     * {@inheritDoc}
+     *
+     * @param array|\Traversable $details
+     */
+    public function setDetails($details)
+    {
+        if ($details instanceof \Traversable) {
+            $details = iterator_to_array($details);
+        }
+
+        $this->details = $details;
+    }
+}

--- a/src/Payum/Core/Model/RefundInterface.php
+++ b/src/Payum/Core/Model/RefundInterface.php
@@ -1,0 +1,18 @@
+<?php
+namespace Payum\Core\Model;
+
+/**
+ * @method array getDetails()
+ */
+interface RefundInterface extends DetailsAggregateInterface, DetailsAwareInterface
+{
+    /**
+     * @return string
+     */
+    public function getOriginalTransactionId();
+
+    /**
+     * @return int
+     */
+    public function getAmount();
+}

--- a/src/Payum/Stripe/Action/ConvertRefundAction.php
+++ b/src/Payum/Stripe/Action/ConvertRefundAction.php
@@ -1,0 +1,44 @@
+<?php
+namespace Payum\Stripe\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Model\RefundInterface;
+use Payum\Core\Request\Convert;
+
+class ConvertRefundAction implements ActionInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param Convert $request
+     */
+    public function execute($request)
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        /** @var RefundInterface $refund */
+        $refund = $request->getSource();
+
+        $details = ArrayObject::ensureArrayObject($refund->getDetails());
+        $details["charge"] = $refund->getOriginalTransactionId();
+        if ($refund->getAmount()) {
+            $details["amount"] = $refund->getAmount();
+        }
+
+        $request->setResult((array) $details);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof Convert &&
+            $request->getSource() instanceof RefundInterface &&
+            $request->getTo() == 'array'
+        ;
+    }
+}

--- a/src/Payum/Stripe/Action/StatusAction.php
+++ b/src/Payum/Stripe/Action/StatusAction.php
@@ -26,13 +26,13 @@ class StatusAction implements ActionInterface
             return;
         }
 
-        if (false == $model['status'] && false == $model['card']) {
+        if (false == $model['status'] && false == $model['card'] && false == $model['charge']) {
             $request->markNew();
 
             return;
         }
 
-        if (false == $model['status'] && $model['card']) {
+        if (false == $model['status'] && ($model['card'] || $model['charge'])) {
             $request->markPending();
 
             return;
@@ -44,7 +44,10 @@ class StatusAction implements ActionInterface
             return;
         }
 
-        if ($model['refunded']) {
+        if ((Constants::OBJECT_CHARGE === $model['object'] && $model['refunded'])
+            || (Constants::STATUS_SUCCEEDED == $model['status']
+            && Constants::OBJECT_REFUND === $model['object'])
+        ) {
             $request->markRefunded();
 
             return;
@@ -62,12 +65,12 @@ class StatusAction implements ActionInterface
             return;
         }
 
-
         if (Constants::STATUS_SUCCEEDED == $model['status'] && false == $model['captured']) {
             $request->markAuthorized();
 
             return;
         }
+
         if (Constants::STATUS_PAID == $model['status'] && false == $model['captured']) {
             $request->markAuthorized();
 

--- a/src/Payum/Stripe/Constants.php
+++ b/src/Payum/Stripe/Constants.php
@@ -9,6 +9,10 @@ class Constants
 
     const STATUS_FAILED = 'failed';
 
+    const OBJECT_CHARGE = 'charge';
+
+    const OBJECT_REFUND = 'refund';
+
     private function __construct()
     {
     }

--- a/src/Payum/Stripe/StripeCheckoutGatewayFactory.php
+++ b/src/Payum/Stripe/StripeCheckoutGatewayFactory.php
@@ -20,6 +20,7 @@ use Payum\Stripe\Action\Api\RetrieveTokenAction;
 use Payum\Stripe\Action\Api\ObtainCardAction;
 use Payum\Stripe\Action\CaptureAction;
 use Payum\Stripe\Action\ConvertPaymentAction;
+use Payum\Stripe\Action\ConvertRefundAction;
 use Payum\Stripe\Action\GetCreditCardTokenAction;
 use Payum\Stripe\Extension\CreateCustomerExtension;
 use Payum\Stripe\Action\StatusAction;
@@ -45,6 +46,7 @@ class StripeCheckoutGatewayFactory extends GatewayFactory
 
             'payum.action.capture' => new CaptureAction(),
             'payum.action.convert_payment' => new ConvertPaymentAction(),
+            'payum.action.convert_refund' => new ConvertRefundAction(),
             'payum.action.status' => new StatusAction(),
             'payum.action.get_credit_card_token' => new GetCreditCardTokenAction(),
             'payum.action.obtain_token' => function (ArrayObject $config) {

--- a/src/Payum/Stripe/Tests/Action/ConvertRefundActionTest.php
+++ b/src/Payum/Stripe/Tests/Action/ConvertRefundActionTest.php
@@ -1,0 +1,111 @@
+<?php
+namespace Payum\Stripe\Tests\Action\Api;
+
+use Payum\Core\Model\CreditCard;
+use Payum\Core\Model\Refund;
+use Payum\Core\Model\RefundInterface;
+use Payum\Core\Request\Convert;
+use Payum\Core\Request\Generic;
+use Payum\Core\Security\SensitiveValue;
+use Payum\Core\Security\TokenInterface;
+use Payum\Core\Tests\GenericActionTest;
+use Payum\Stripe\Action\ConvertRefundAction;
+
+class ConvertRefundActionTest extends GenericActionTest
+{
+    protected $actionClass = ConvertRefundAction::class;
+
+    protected $requestClass = Convert::class;
+
+    public function provideSupportedRequests()
+    {
+        return array(
+            array(new $this->requestClass(new Refund(), 'array')),
+            array(new $this->requestClass($this->getMock(RefundInterface::class), 'array')),
+            array(new $this->requestClass(new Refund(), 'array', $this->getMock(TokenInterface::class))),
+        );
+    }
+
+    public function provideNotSupportedRequests()
+    {
+        return array(
+            array('foo'),
+            array(array('foo')),
+            array(new \stdClass()),
+            array($this->getMockForAbstractClass(Generic::class, array(array()))),
+            array(new $this->requestClass(new \stdClass(), 'array')),
+            array(new $this->requestClass(new Refund(), 'foobar')),
+            array(new $this->requestClass($this->getMock(RefundInterface::class), 'foobar')),
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldCorrectlyConvertRefundToDetails()
+    {
+        $refund = new Refund();
+        $refund->setOriginalTransactionId('originalTransactionId');
+        $refund->setAmount(123);
+
+        $action = new ConvertRefundAction();
+
+        $action->execute($convert = new Convert($refund, 'array'));
+
+        $details = $convert->getResult();
+
+        $this->assertNotEmpty($details);
+
+        $this->assertArrayHasKey('amount', $details);
+        $this->assertEquals(123, $details['amount']);
+
+        $this->assertArrayHasKey('charge', $details);
+        $this->assertEquals('originalTransactionId', $details['charge']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotSetOptionalValuesIntoDetails()
+    {
+        $refund = new Refund();
+        $refund->setOriginalTransactionId('originalTransactionId');
+
+        $action = new ConvertRefundAction();
+
+        $action->execute($convert = new Convert($refund, 'array'));
+
+        $details = $convert->getResult();
+
+        $this->assertNotEmpty($details);
+
+        $this->assertArrayNotHasKey('amount', $details);
+
+        $this->assertArrayHasKey('charge', $details);
+        $this->assertEquals('originalTransactionId', $details['charge']);
+    }
+
+    /**
+     * @test
+     */
+    public function shouldNotOverwriteAlreadySetExtraDetails()
+    {
+        $refund = new Refund();
+        $refund->setOriginalTransactionId('originalTransactionId');
+        $refund->setAmount(123);
+        $refund->setDetails(array(
+            'foo' => 'fooVal',
+        ));
+
+        $action = new ConvertRefundAction();
+
+        $action->execute($convert = new Convert($refund, 'array'));
+
+        $details = $convert->getResult();
+
+        $this->assertNotEmpty($details);
+
+        $this->assertArrayHasKey('foo', $details);
+        $this->assertEquals('fooVal', $details['foo']);
+    }
+}

--- a/src/Payum/Stripe/Tests/Action/StatusActionTest.php
+++ b/src/Payum/Stripe/Tests/Action/StatusActionTest.php
@@ -62,6 +62,22 @@ class StatusActionTest extends GenericActionTest
         $this->assertTrue($status->isPending());
     }
 
+     /**
+     * @test
+     */
+    public function shouldMarkPendingIfModelHasNotStatusButHasCharge()
+    {
+        $action = new StatusAction();
+
+        $model = array(
+            'charge' => 'charge_id',
+        );
+
+        $action->execute($status = new GetHumanStatus($model));
+
+        $this->assertTrue($status->isPending());
+    }
+
     /**
      * @test
      */
@@ -86,8 +102,26 @@ class StatusActionTest extends GenericActionTest
         $action = new StatusAction();
 
         $model = array(
+            'object' => Constants::OBJECT_CHARGE,
             'status' => Constants::STATUS_SUCCEEDED,
             'refunded' => true,
+        );
+
+        $action->execute($status = new GetHumanStatus($model));
+
+        $this->assertTrue($status->isRefunded());
+    }
+
+     /**
+     * @test
+     */
+    public function shouldMarkRefundedIfStatusSetAndObjectIsRefund()
+    {
+        $action = new StatusAction();
+
+        $model = array(
+            'object' => Constants::OBJECT_REFUND,
+            'status' => Constants::STATUS_SUCCEEDED,
         );
 
         $action->execute($status = new GetHumanStatus($model));
@@ -103,6 +137,7 @@ class StatusActionTest extends GenericActionTest
         $action = new StatusAction();
 
         $model = array(
+            'object' => Constants::OBJECT_CHARGE,
             'refunded' => true,
         );
 


### PR DESCRIPTION
This PR adds:
- a RefundInterface that can be used as the Model of a Refund Request
- a standard Refund Model for requesting a refund in any Gateway
- a Stripe Convert Action that will convert the Refund model into Sripe-aware model
- some changes in stripe's StatusAction to handle Refund statuses
- tests
