### PR TITLE
Add GetError Model and Stripe ErrorAction

### DIFF
--- a/src/Payum/Core/Request/GetError.php
+++ b/src/Payum/Core/Request/GetError.php
@@ -1,0 +1,139 @@
+<?php
+namespace Payum\Core\Request;
+
+class GetError extends Generic implements GetErrorInterface
+{
+    const CREDIT_CARD_INVALID = 'credit_card_invalid';
+    const CREDIT_CARD_EXPIRED = 'credit_card_expired';
+    const CREDIT_CARD_DECLINED = 'credit_card_declined';
+    const CREDIT_CARD_MISSING = 'credit_card_missing';
+    const INVALID_REQUEST = 'invalid_request';
+    const UNKNOWN = 'unknown';
+
+    protected $error_code;
+
+    protected $original_error_code;
+
+    /**
+     * {@inheritDoc}
+     */
+    public function __construct($model)
+    {
+        parent::__construct($model);
+
+        $this->markUnknown();
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getValue()
+    {
+        return $this->error_code;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function getOriginalErrorCode()
+    {
+        return $this->original_error_code;
+    }
+
+    /**
+     * @return mixed
+     */
+    public function setOriginalErrorCode($error_code)
+    {
+        $this->original_error_code = $error_code;
+    }
+
+    /**
+     * @return void
+     */
+    public function markInvalidCreditCard()
+    {
+        $this->error_code = self::CREDIT_CARD_INVALID;
+    }
+
+    /**
+     * @return void
+     */
+    public function markExpiredCreditCard()
+    {
+        $this->error_code = self::CREDIT_CARD_EXPIRED;
+    }
+
+    /**
+     * @return void
+     */
+    public function markDeclinedCreditCard()
+    {
+        $this->error_code = self::CREDIT_CARD_DECLINED;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function markMissingCreditCard()
+    {
+        $this->error_code = self::CREDIT_CARD_MISSING;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function markInvalidRequest()
+    {
+        $this->error_code = self::INVALID_REQUEST;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function markUnknown()
+    {
+        $this->error_code = self::UNKNOWN;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isInvalidCreditCard()
+    {
+        return $this->error_code === self::CREDIT_CARD_INVALID;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isExpiredCreditCard()
+    {
+        return $this->error_code === self::CREDIT_CARD_EXPIRED;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isDeclinedCreditCard()
+    {
+        return $this->error_code === self::CREDIT_CARD_DECLINED;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isMissingCreditCard()
+    {
+        return $this->error_code === self::CREDIT_CARD_MISSING;
+    }
+
+    /**
+     * @return boolean
+     */
+    public function isUnknown()
+    {
+        return $this->error_code === self::UNKNOWN;
+    }
+
+}

--- a/src/Payum/Core/Request/GetErrorInterface.php
+++ b/src/Payum/Core/Request/GetErrorInterface.php
@@ -1,0 +1,73 @@
+<?php
+namespace Payum\Core\Request;
+
+use Payum\Core\Model\ModelAggregateInterface;
+use Payum\Core\Model\ModelAwareInterface;
+
+interface GetErrorInterface extends ModelAwareInterface, ModelAggregateInterface
+{
+    /**
+     * @return mixed
+     */
+    public function getValue();
+
+    /**
+     * @return mixed
+     */
+    public function getOriginalErrorCode();
+
+    /**
+     * @return mixed
+     */
+    public function setOriginalErrorCode($error_code);
+
+    /**
+     * @return void
+     */
+    public function markInvalidCreditCard();
+
+    /**
+     * @return void
+     */
+    public function markExpiredCreditCard();
+
+    /**
+     * @return void
+     */
+    public function markDeclinedCreditCard();
+
+    /**
+     * @return boolean
+     */
+    public function markMissingCreditCard();
+
+    /**
+     * @return boolean
+     */
+    public function markUnknown();
+
+    /**
+     * @return boolean
+     */
+    public function isInvalidCreditCard();
+
+    /**
+     * @return boolean
+     */
+    public function isExpiredCreditCard();
+
+    /**
+     * @return boolean
+     */
+    public function isDeclinedCreditCard();
+
+    /**
+     * @return boolean
+     */
+    public function isMissingCreditCard();
+
+    /**
+     * @return boolean
+     */
+    public function isUnknown();
+}

--- a/src/Payum/Stripe/Action/ErrorAction.php
+++ b/src/Payum/Stripe/Action/ErrorAction.php
@@ -1,0 +1,62 @@
+<?php
+namespace Payum\Stripe\Action;
+
+use Payum\Core\Action\ActionInterface;
+use Payum\Core\Bridge\Spl\ArrayObject;
+use Payum\Core\Exception\RequestNotSupportedException;
+use Payum\Core\Request\GetErrorInterface;
+use Payum\Stripe\Constants;
+
+class ErrorAction implements ActionInterface
+{
+    /**
+     * {@inheritDoc}
+     *
+     * @param GetStatusInterface $request
+     */
+    public function execute($request)
+    {
+        RequestNotSupportedException::assertSupports($this, $request);
+
+        $model = ArrayObject::ensureArrayObject($request->getModel());
+
+        if (@$model['error']) {
+            $request->setOriginalErrorCode(
+                @$model['error']['code'] ?: @$model['error']['type'] ?: @$model['error']['message']
+            );
+            if (@$model['error']['type'] === 'card_error') {
+                switch ($model['error']['code']) {
+                    case 'invalid_number':
+                    case 'invalid_expiry_month':
+                    case 'invalid_expiry_year':
+                    case 'invalid_cvc':
+                    case 'incorrect_cvc':
+                    case 'incorrect_number':
+                    case 'incorrect_zip':
+                        $request->markInvalidCreditCard();
+                        break;
+                    case 'expired_card':
+                        $request->markExpiredCreditCard();
+                        break;
+                    case 'card_declined':
+                        $request->markDeclinedCreditCard();
+                        break;
+                    case 'missing':
+                        $request->markMissingCreditCard();
+                        break;
+                }
+            }
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public function supports($request)
+    {
+        return
+            $request instanceof GetErrorInterface &&
+            $request->getModel() instanceof \ArrayAccess
+        ;
+    }
+}

--- a/src/Payum/Stripe/StripeCheckoutGatewayFactory.php
+++ b/src/Payum/Stripe/StripeCheckoutGatewayFactory.php
@@ -14,6 +14,7 @@ use Payum\Stripe\Action\ConvertPaymentAction;
 use Payum\Stripe\Action\GetCreditCardTokenAction;
 use Payum\Stripe\Extension\CreateCustomerExtension;
 use Payum\Stripe\Action\StatusAction;
+use Payum\Stripe\Action\ErrorAction;
 use Stripe\Stripe;
 
 class StripeCheckoutGatewayFactory extends GatewayFactory
@@ -36,6 +37,7 @@ class StripeCheckoutGatewayFactory extends GatewayFactory
             'payum.action.capture' => new CaptureAction(),
             'payum.action.convert_payment' => new ConvertPaymentAction(),
             'payum.action.status' => new StatusAction(),
+            'payum.action.error' => new ErrorAction(),
             'payum.action.get_credit_card_token' => new GetCreditCardTokenAction(),
             'payum.action.obtain_token' => function (ArrayObject $config) {
                 return new ObtainTokenAction($config['payum.template.obtain_token']);

--- a/src/Payum/Stripe/Tests/Action/ErrorActionTest.php
+++ b/src/Payum/Stripe/Tests/Action/ErrorActionTest.php
@@ -1,0 +1,284 @@
+<?php
+namespace Payum\Stripe\Tests\Action\Api;
+
+use Payum\Core\Request\GetError;
+use Payum\Core\Tests\GenericActionTest;
+use Payum\Stripe\Action\ErrorAction;
+use Payum\Stripe\Constants;
+
+class ErrorActionTest extends GenericActionTest
+{
+    protected $requestClass = GetError::class;
+
+    protected $actionClass = ErrorAction::class;
+
+    /**
+     * @test
+     */
+    public function shouldMarkInvalidCardIfNumberIsInvalid()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'invalid_number',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isInvalidCreditCard());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldMarkInvalidCardIfExpiryMonthIsInvalid()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'invalid_expiry_month',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isInvalidCreditCard());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldMarkInvalidCardIfExpiryYearIsInvalid()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'invalid_expiry_year',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isInvalidCreditCard());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldMarkInvalidCardIfCVCIsInvalid()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'invalid_cvc',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isInvalidCreditCard());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldMarkInvalidCardIfCVCCIsIncorrect()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'incorrect_cvc',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isInvalidCreditCard());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldMarkInvalidCardIfNumnerIsIncorrect()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'incorrect_number',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isInvalidCreditCard());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldMarkFailedIfZipIsIncorrect()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'incorrect_zip',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isInvalidCreditCard());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldMarkExpiredCardIfCardIsExpired()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'expired_card',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isExpiredCreditCard());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldMarkDeclinedCardIfCardisExpired()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'card_declined',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isDeclinedCreditCard());
+    }
+
+
+    /**
+     * @test
+     */
+    public function shouldMarkIMissingCardIfCardIsMIssing()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'missing',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isMissingCreditCard());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetTheOriginalErrorCodeCorrectlyFromCode()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'card_error',
+                'code' => 'unknown_error',
+                'message' => 'This is an error message',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertEquals('unknown_error', $error->getOriginalErrorCode());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetTheOriginalErrorCodeCorrectlyFromType()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'type' => 'invalid_request_error',
+                'message' => 'This is an error message',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertEquals('invalid_request_error', $error->getOriginalErrorCode());
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetTheOriginalErrorCodeCorrectlyFromMessage()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'message' => 'This is an error message',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertEquals(
+            'This is an error message',
+            $error->getOriginalErrorCode()
+        );
+    }
+
+    /**
+     * @test
+     */
+    public function shouldSetUnknownErrorWhenErrorIsUnknown()
+    {
+        $action = new ErrorAction();
+
+        $model = [
+            'error' => [
+                'foo' => 'bar',
+            ],
+        ];
+
+        $action->execute($error = new GetError($model));
+
+        $this->assertTrue($error->isUnknown());
+    }
+
+}


### PR DESCRIPTION
Adds a Error getter to get errors in a "normalized" way (for now, just for "standard" credit card errors)
Also, it allows to get the original error code and messages. Could be useful when the gateway has some rare or specific errors. 

You can now can do something like:

```
if ($status->isFailed()) {
    $errorRequest = new GetError($refundRequest->getModel());
    $payum->getGateway('stripe_js')->execute($errorRequest);
    $errorRequest->isInvalidCreditCard(); // the card provided was invalid
    $errorRequest->isDeclinedCreditCard(): // the card provided was declined
    ...
    $errorRequest->getOriginalErrorCode(); // the original error code from the gateway
    $errorRequest->getOriginalErrorMessage(); // the original error code from the gateway
}
```
